### PR TITLE
Support for Unix file descriptors + async calls

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -84,7 +84,8 @@ All objects have methods, properties and signals.
 Setting up an event loop
 ========================
 
-To handle signals emitted by exported objects, or to export your own objects, you need to setup an event loop.
+To handle signals emitted by exported objects, to asynchronously call methods
+or to export your own objects, you need to setup an event loop.
 
 The only main loop supported by ``pydbus`` is GLib.MainLoop.
 
@@ -155,6 +156,14 @@ To see the API of a specific proxy object, use help()::
 To call a method::
 
     dev.Disconnect()
+
+To asynchronously call a method::
+
+    def print_result(returned=None, error=None):
+        print(returned, error)
+
+    dev.GetAppliedConnection(0, callback=print_result)
+    loop.run()
 
 To read a property::
 

--- a/pydbus/proxy_method.py
+++ b/pydbus/proxy_method.py
@@ -69,7 +69,6 @@ class ProxyMethod(object):
 			if kwarg not in ("timeout", "callback", "callback_args"):
 				raise TypeError(self.__qualname__ + " got an unexpected keyword argument '{}'".format(kwarg))
 		timeout = kwargs.get("timeout", None)
-
 		callback = kwargs.get("callback", None)
 		callback_args = kwargs.get("callback_args", tuple())
 
@@ -112,7 +111,6 @@ class ProxyMethod(object):
 			values.unpack(),
 			self._outargs,
 			fd_list)
-
 		if len(self._outargs) == 0:
 			return None
 		elif len(self._outargs) == 1:

--- a/pydbus/proxy_method.py
+++ b/pydbus/proxy_method.py
@@ -72,7 +72,6 @@ class ProxyMethod(object):
 
 		if unixfd.is_supported(instance._bus.con):
 			fd_list = unixfd.make_fd_list(
-				instance._bus.con,
 				args,
 				[arg[1] for arg in self._inargs])
 			ret, fd_list = instance._bus.con.call_with_unix_fd_list_sync(
@@ -80,7 +79,6 @@ class ProxyMethod(object):
 				self._iface_name, self.__name__, GLib.Variant(self._sinargs, args), GLib.VariantType.new(self._soutargs),
 				0, timeout_to_glib(timeout), fd_list, None)
 			ret = unixfd.extract(
-				instance._bus.con,
 				ret.unpack(),
 				self._outargs,
 				fd_list)

--- a/pydbus/proxy_method.py
+++ b/pydbus/proxy_method.py
@@ -2,6 +2,7 @@ from gi.repository import GLib
 from .generic import bound_method
 from .identifier import filter_identifier
 from .timeout import timeout_to_glib
+from . import unixfd
 
 try:
 	from inspect import Signature, Parameter
@@ -69,10 +70,25 @@ class ProxyMethod(object):
 				raise TypeError(self.__qualname__ + " got an unexpected keyword argument '{}'".format(kwarg))
 		timeout = kwargs.get("timeout", None)
 
-		ret = instance._bus.con.call_sync(
-			instance._bus_name, instance._path,
-			self._iface_name, self.__name__, GLib.Variant(self._sinargs, args), GLib.VariantType.new(self._soutargs),
-			0, timeout_to_glib(timeout), None).unpack()
+		if unixfd.is_supported(instance._bus.con):
+			fd_list = unixfd.make_fd_list(
+				instance._bus.con,
+				args,
+				[arg[1] for arg in self._inargs])
+			ret, fd_list = instance._bus.con.call_with_unix_fd_list_sync(
+				instance._bus_name, instance._path,
+				self._iface_name, self.__name__, GLib.Variant(self._sinargs, args), GLib.VariantType.new(self._soutargs),
+				0, timeout_to_glib(timeout), fd_list, None)
+			ret = unixfd.extract(
+				instance._bus.con,
+				ret.unpack(),
+				self._outargs,
+				fd_list)
+		else:
+			ret = instance._bus.con.call_sync(
+				instance._bus_name, instance._path,
+				self._iface_name, self.__name__, GLib.Variant(self._sinargs, args), GLib.VariantType.new(self._soutargs),
+				0, timeout_to_glib(timeout), None)
 
 		if len(self._outargs) == 0:
 			return None

--- a/pydbus/registration.py
+++ b/pydbus/registration.py
@@ -5,6 +5,7 @@ from . import generic
 from .exitable import ExitableWithAliases
 from functools import partial
 from .method_call_context import MethodCallContext
+from . import unixfd
 import logging
 
 try:
@@ -18,10 +19,12 @@ class ObjectWrapper(ExitableWithAliases("unwrap")):
 	def __init__(self, object, interfaces):
 		self.object = object
 
+		self.inargs = {}
 		self.outargs = {}
 		for iface in interfaces:
 			for method in iface.methods:
 				self.outargs[iface.name + "." + method.name] = [arg.signature for arg in method.out_args]
+				self.inargs[iface.name + "." + method.name] = [arg.signature for arg in method.in_args]
 
 		self.readable_properties = {}
 		self.writable_properties = {}
@@ -54,6 +57,7 @@ class ObjectWrapper(ExitableWithAliases("unwrap")):
 	def call_method(self, connection, sender, object_path, interface_name, method_name, parameters, invocation):
 		try:
 			try:
+				inargs = self.inargs[interface_name + "." + method_name]
 				outargs = self.outargs[interface_name + "." + method_name]
 				method = getattr(self.object, method_name)
 			except KeyError:
@@ -78,14 +82,24 @@ class ObjectWrapper(ExitableWithAliases("unwrap")):
 			if "dbus_context" in sig.parameters and sig.parameters["dbus_context"].kind in (Parameter.POSITIONAL_OR_KEYWORD, Parameter.KEYWORD_ONLY):
 				kwargs["dbus_context"] = MethodCallContext(invocation)
 
+			if unixfd.is_supported(connection):
+				parameters = unixfd.extract(
+					connection,
+					parameters,
+					inargs,
+					invocation.get_message().get_unix_fd_list())
+
 			result = method(*parameters, **kwargs)
 
 			if len(outargs) == 0:
 				invocation.return_value(None)
-			elif len(outargs) == 1:
-				invocation.return_value(GLib.Variant("(" + "".join(outargs) + ")", (result,)))
 			else:
-				invocation.return_value(GLib.Variant("(" + "".join(outargs) + ")", result))
+				if len(outargs) == 1:
+					result = (result, )
+				if unixfd.is_supported(connection):
+					invocation.return_value_with_unix_fd_list(GLib.Variant("(" + "".join(outargs) + ")", result), unixfd.make_fd_list(connection, result, outargs))
+				else:
+					invocation.return_value(GLib.Variant("(" + "".join(outargs) + ")", result))
 
 		except Exception as e:
 			logger = logging.getLogger(__name__)
@@ -151,6 +165,5 @@ class RegistrationMixin:
 
 		node_info = [Gio.DBusNodeInfo.new_for_xml(ni) for ni in node_info]
 		interfaces = sum((ni.interfaces for ni in node_info), [])
-
 		wrapper = ObjectWrapper(object, interfaces)
 		return ObjectRegistration(self, path, interfaces, wrapper, own_wrapper=True)

--- a/pydbus/registration.py
+++ b/pydbus/registration.py
@@ -84,7 +84,6 @@ class ObjectWrapper(ExitableWithAliases("unwrap")):
 
 			if unixfd.is_supported(connection):
 				parameters = unixfd.extract(
-					connection,
 					parameters,
 					inargs,
 					invocation.get_message().get_unix_fd_list())
@@ -97,7 +96,7 @@ class ObjectWrapper(ExitableWithAliases("unwrap")):
 				if len(outargs) == 1:
 					result = (result, )
 				if unixfd.is_supported(connection):
-					invocation.return_value_with_unix_fd_list(GLib.Variant("(" + "".join(outargs) + ")", result), unixfd.make_fd_list(connection, result, outargs))
+					invocation.return_value_with_unix_fd_list(GLib.Variant("(" + "".join(outargs) + ")", result), unixfd.make_fd_list(result, outargs))
 				else:
 					invocation.return_value(GLib.Variant("(" + "".join(outargs) + ")", result))
 

--- a/pydbus/registration.py
+++ b/pydbus/registration.py
@@ -96,7 +96,7 @@ class ObjectWrapper(ExitableWithAliases("unwrap")):
 				if len(outargs) == 1:
 					result = (result, )
 				if unixfd.is_supported(connection):
-					invocation.return_value_with_unix_fd_list(GLib.Variant("(" + "".join(outargs) + ")", result), unixfd.make_fd_list(result, outargs))
+					invocation.return_value_with_unix_fd_list(GLib.Variant("(" + "".join(outargs) + ")", result), unixfd.make_fd_list(result, outargs, steal=True))
 				else:
 					invocation.return_value(GLib.Variant("(" + "".join(outargs) + ")", result))
 

--- a/pydbus/unixfd.py
+++ b/pydbus/unixfd.py
@@ -1,0 +1,53 @@
+from gi.repository import Gio
+
+# signature type code
+TYPE_FD = "h"
+
+def is_supported(conn):
+	"""
+	Check if the message bus supports passing of Unix file descriptors.
+	"""
+	return conn.get_capabilities() & Gio.DBusCapabilityFlags.UNIX_FD_PASSING
+
+
+def extract(params, signature, fd_list):
+	"""
+	Extract any file descriptors from a UnixFDList (e.g. after
+	receiving from D-Bus) to a parameter list.
+	Receiver must call os.dup on any fd it decides to keep/use.
+	"""
+	if not fd_list:
+		return params
+	return [fd_list.get(0)
+		if arg == TYPE_FD
+		else val
+		for val, arg
+		in zip(params, signature)]
+
+
+def make_fd_list(params, signature, steal=False):
+	"""
+	Embed any unix file descriptors in a parameter list into a
+	UnixFDList (for D-Bus-dispatch).
+	If steal is true, the responsibility for closing the file
+	descriptors are transferred to the UnixFDList object.
+	If steal is false, the file descriptors will be duplicated
+	and the caller must close the original file descriptors.
+	"""
+	if not any(arg
+		   for arg in signature
+		   if arg == TYPE_FD):
+		return None
+
+	fds = [param
+	       for param, arg
+	       in zip(params, signature)
+	       if arg == TYPE_FD]
+
+	if steal:
+		return Gio.UnixFDList.new_from_array(fds)
+
+	fd_list = Gio.UnixFDList()
+	for fd in fds:
+		fd_list.append(fd)
+	return fd_list

--- a/pydbus/unixfd.py
+++ b/pydbus/unixfd.py
@@ -1,0 +1,50 @@
+from gi.repository import Gio
+
+# signature type code
+TYPE_FD = "h"
+
+def is_supported(conn):
+	"""
+	Check if the message bus supports passing of Unix file descriptors.
+	"""
+	return conn.get_capabilities() & Gio.DBusCapabilityFlags.UNIX_FD_PASSING
+
+
+def extract(conn, params, signature, fd_list):
+	"""
+	Extract any file descriptors from a UnixFDList (e.g. after
+	receiving from D-Bus) to a parameter list.
+	Receiver must call os.dup on any fd it decides to keep/use.
+	"""
+	if not is_supported(conn):
+		return params
+	if not fd_list:
+		return params
+	fd_list = (fd
+		   for fd
+		   in fd_list.peek_fds())
+	return [next(fd_list)
+		if arg == TYPE_FD
+		else val
+		for val, arg
+		in zip(params, signature)]
+
+
+def make_fd_list(conn, params, signature):
+	"""
+	Embed any unix file descriptors in a parameter list into a
+	UnixFDList (for D-Bus-dispatch).
+	"""
+	if not is_supported(conn):
+		return None
+	if not any(arg
+		   for arg in signature
+		   if arg == TYPE_FD):
+		return None
+	fd_list = Gio.UnixFDList()
+	for fd in [param
+		   for param, arg
+		   in zip(params, signature)
+		   if arg == TYPE_FD]:
+		fd_list.append(fd)
+	return fd_list

--- a/pydbus/unixfd.py
+++ b/pydbus/unixfd.py
@@ -18,29 +18,36 @@ def extract(params, signature, fd_list):
 	"""
 	if not fd_list:
 		return params
-	fd_list = (fd
-		   for fd
-		   in fd_list.peek_fds())
-	return [next(fd_list)
+	return [fd_list.get(0)
 		if arg == TYPE_FD
 		else val
 		for val, arg
 		in zip(params, signature)]
 
 
-def make_fd_list(params, signature):
+def make_fd_list(params, signature, steal=False):
 	"""
 	Embed any unix file descriptors in a parameter list into a
 	UnixFDList (for D-Bus-dispatch).
+	If steal is true, the responsibility for closing the file
+	descriptors are transferred to the UnixFDList object.
+	If steal is false, the file descriptors will be duplicated
+	and the caller must close the original file descriptors.
 	"""
 	if not any(arg
 		   for arg in signature
 		   if arg == TYPE_FD):
 		return None
+
+	fds = [param
+	       for param, arg
+	       in zip(params, signature)
+	       if arg == TYPE_FD]
+
+	if steal:
+		return Gio.UnixFDList.new_from_array(fds)
+
 	fd_list = Gio.UnixFDList()
-	for fd in [param
-		   for param, arg
-		   in zip(params, signature)
-		   if arg == TYPE_FD]:
+	for fd in fds:
 		fd_list.append(fd)
 	return fd_list

--- a/pydbus/unixfd.py
+++ b/pydbus/unixfd.py
@@ -10,14 +10,12 @@ def is_supported(conn):
 	return conn.get_capabilities() & Gio.DBusCapabilityFlags.UNIX_FD_PASSING
 
 
-def extract(conn, params, signature, fd_list):
+def extract(params, signature, fd_list):
 	"""
 	Extract any file descriptors from a UnixFDList (e.g. after
 	receiving from D-Bus) to a parameter list.
 	Receiver must call os.dup on any fd it decides to keep/use.
 	"""
-	if not is_supported(conn):
-		return params
 	if not fd_list:
 		return params
 	fd_list = (fd
@@ -30,13 +28,11 @@ def extract(conn, params, signature, fd_list):
 		in zip(params, signature)]
 
 
-def make_fd_list(conn, params, signature):
+def make_fd_list(params, signature):
 	"""
 	Embed any unix file descriptors in a parameter list into a
 	UnixFDList (for D-Bus-dispatch).
 	"""
-	if not is_supported(conn):
-		return None
 	if not any(arg
 		   for arg in signature
 		   if arg == TYPE_FD):

--- a/tests/publish_async.py
+++ b/tests/publish_async.py
@@ -1,0 +1,63 @@
+from pydbus import SessionBus
+from gi.repository import GLib
+from threading import Thread
+import sys
+
+done = 0
+loop = GLib.MainLoop()
+
+class TestObject(object):
+	'''
+<node>
+	<interface name='net.lew21.pydbus.tests.publish_async'>
+		<method name='HelloWorld'>
+			<arg type='i' name='x' direction='in'/>
+			<arg type='s' name='response' direction='out'/>
+		</method>
+	</interface>
+</node>
+	'''
+	def __init__(self, id):
+		self.id = id
+
+	def HelloWorld(self, x):
+		res = self.id + ": " + str(x)
+		print(res)
+		return res
+
+bus = SessionBus()
+
+with bus.publish("net.lew21.pydbus.tests.publish_async", TestObject("Obj")):
+	remote = bus.get("net.lew21.pydbus.tests.publish_async")
+
+	def callback(x, returned=None, error=None):
+		print("asyn: " + returned)
+		assert (returned is not None)
+		assert(error is None)
+		assert(x == int(returned.split()[1]))
+
+		global done
+		done += 1
+		if done == 3:
+			loop.quit()
+
+	def t1_func():
+		remote.HelloWorld(1, callback=callback, callback_args=(1,))
+		remote.HelloWorld(2, callback=callback, callback_args=(2,))
+		print("sync: " + remote.HelloWorld(3))
+		remote.HelloWorld(4, callback=callback, callback_args=(4,))
+
+	t1 = Thread(None, t1_func)
+	t1.daemon = True
+
+	def handle_timeout():
+		print("ERROR: Timeout.")
+		sys.exit(1)
+
+	GLib.timeout_add_seconds(2, handle_timeout)
+
+	t1.start()
+
+	loop.run()
+
+	t1.join()

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,4 +15,5 @@ then
 	"$PYTHON" $TESTS_DIR/publish.py
 	"$PYTHON" $TESTS_DIR/publish_properties.py
 	"$PYTHON" $TESTS_DIR/publish_multiface.py
+	"$PYTHON" $TESTS_DIR/publish_async.py
 fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,4 +15,5 @@ then
 	"$PYTHON" $TESTS_DIR/publish.py
 	"$PYTHON" $TESTS_DIR/publish_properties.py
 	"$PYTHON" $TESTS_DIR/publish_multiface.py
+	"$PYTHON" $TESTS_DIR/unixfd.py
 fi

--- a/tests/unixfd.py
+++ b/tests/unixfd.py
@@ -1,0 +1,60 @@
+from pydbus import SessionBus
+from gi.repository import GLib
+from threading import Thread
+import sys
+import os
+
+loop = GLib.MainLoop()
+
+
+with open(__file__) as f:
+	contents = f.read()
+
+
+class TestObject(object):
+	"""
+	<node>
+	<interface name="baz.bar.Foo">
+		<method name="Hello">
+			<arg type="h" name="in_fd" direction="in"/>
+			<arg type="h" name="out_fd" direction="out"/>
+		</method>
+	</interface>
+	</node>
+	"""
+	def Hello(self, in_fd):
+		with os.fdopen(in_fd) as in_file:
+			in_file.seek(0)
+			assert(contents == in_file.read())
+			print("Received fd as in parameter ok")
+		with open(__file__) as out_file:
+			assert(contents == out_file.read())
+			return os.dup(out_file.fileno())
+
+bus = SessionBus()
+
+
+with bus.publish("baz.bar.Foo", TestObject()):
+	remote = bus.get("baz.bar.Foo")
+
+	def thread_func():
+		with open(__file__) as in_file:
+			assert(contents == in_file.read())
+			out_fd = remote.Hello(in_file.fileno())
+			with os.fdopen(out_fd) as out_file:
+				out_file.seek(0)
+				assert(contents == out_file.read())
+				print("Received fd as out argument ok")
+		loop.quit()
+
+	thread = Thread(target=thread_func)
+	thread.daemon = True
+
+	def handle_timeout():
+		exit("ERROR: Timeout.")
+
+	GLib.timeout_add_seconds(2, handle_timeout)
+
+	thread.start()
+	loop.run()
+	thread.join()

--- a/tests/unixfd.py
+++ b/tests/unixfd.py
@@ -1,0 +1,58 @@
+from pydbus import SessionBus
+from gi.repository import GLib
+from threading import Thread
+import sys
+import os
+import pathlib
+
+loop = GLib.MainLoop()
+contents = pathlib.Path(__file__).read_text()
+
+
+class TestObject(object):
+	"""
+	<node>
+	<interface name="baz.bar.Foo">
+		<method name="Hello">
+			<arg type="h" name="in_fd" direction="in"/>
+			<arg type="h" name="out_fd" direction="out"/>
+		</method>
+	</interface>
+	</node>
+	"""
+	def Hello(self, in_fd):
+		with open(in_fd) as in_file:
+			in_file.seek(0)
+			assert(contents == in_file.read())
+			print("Received fd as in parameter ok")
+		with open(__file__) as out_file:
+			assert(contents == out_file.read())
+			return os.dup(out_file.fileno())
+
+bus = SessionBus()
+
+
+with bus.publish("baz.bar.Foo", TestObject()):
+	remote = bus.get("baz.bar.Foo")
+
+	def thread_func():
+		with open(__file__) as in_file:
+			assert(contents == in_file.read())
+			out_fd = remote.Hello(in_file.fileno())
+			with open(out_fd) as out_file:
+				out_file.seek(0)
+				assert(contents == out_file.read())
+				print("Received fd as out argument ok")
+		loop.quit()
+
+	thread = Thread(target=thread_func)
+	thread.daemon = True
+
+	def handle_timeout():
+		exit("ERROR: Timeout.")
+
+	GLib.timeout_add_seconds(2, handle_timeout)
+
+	thread.start()
+	loop.run()
+	thread.join()


### PR DESCRIPTION
### Unix file descriptors

Semantics for file descriptor ownership should probably be described in the documentation. Any file descriptor as `out` parameter will be closed by the dbus interface and should not be closed by the sender (just passed as `return`). Any file desciptor as `in`-parameter is only valid for the duration of the call and will be closed by the dbus interface. If the receiver wants to keep it, it should be duplicated using `os.dup`.

### Asynchronous calls

Added support for asynchronous calls of methods. A method is called
synchronously unless its callback parameter is specified. A callback
is a function f(*args, returned=None, error=None), where args is
callback_args specified in the method call, returned is a return
value of the method and error is an exception raised by the method.

Example of an asynchronous call:

```python
def func(x, y, returned=None, error=None):
  pass

proxy.Method(a, b, callback=func, callback_args=(x, y))
```